### PR TITLE
fix: combine server and nginx into single pod

### DIFF
--- a/.github/workflows/deploy-prod&demo.yaml
+++ b/.github/workflows/deploy-prod&demo.yaml
@@ -11,73 +11,52 @@ on:
   workflow_dispatch:
 
 jobs:
-  build-and-deploy-server:
-    name: Deploy server to prod on merge to main branch
-    uses: Informasjonsforvaltning/workflows/.github/workflows/build-deploy-nox.yaml@main
+  build-server:
+    name: Build server image
+    uses: Informasjonsforvaltning/workflows/.github/workflows/build-push.yaml@main
     with:
       app_name: static-rdf-server
-      python_version: "3.12"
-      python_architecture: x64
-      node_version: 16
       environment: prod
+      gh_environment: prod
+    secrets:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  build-nginx:
+    name: Build nginx image
+    uses: Informasjonsforvaltning/workflows/.github/workflows/build-push.yaml@main
+    with:
+      app_name: static-rdf-nginx
+      environment: prod
+      gh_environment: prod
+      dockerfile: Dockerfile
+      build_context: ./nginx/
+    secrets:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  deploy-prod:
+    name: Deploy to prod environment
+    needs: [build-server, build-nginx]
+    uses: Informasjonsforvaltning/workflows/.github/workflows/kustomize-deploy.yaml@main
+    with:
+      app_name: static-rdf-server
+      environment: prod
+      gh_environment: prod
       cluster: digdir-fdk-prod
-      nox_image: True
-      nox_env: 1
-      nox_env_1_name: API_KEY
-      snapshot_disk: fdk-prod-static-rdf-server
-      snapshot_name: autodeploy-prod-static-rdf-server
-      snapshot_zone: europe-north1-a
     secrets:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       DIGDIR_FDK_AUTODEPLOY: ${{ secrets.DIGDIR_FDK_PROD_AUTODEPLOY }}
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-      NOX_ENV_1_VALUE: ${{ secrets.TEST_API_KEY }}
 
-  deploy-server-to-demo:
-    needs: build-and-deploy-server
-    name: Deploy server to demo if prod-deploy is successful
-    uses: Informasjonsforvaltning/workflows/.github/workflows/deploy.yaml@main
+  deploy-demo:
+    name: Deploy to demo if prod-deploy is successful
+    needs: deploy-prod
+    uses: Informasjonsforvaltning/workflows/.github/workflows/kustomize-deploy.yaml@main
     with:
       app_name: static-rdf-server
       environment: demo
+      gh_environment: demo
       cluster: digdir-fdk-dev
     secrets:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      DIGDIR_FDK_AUTODEPLOY: ${{ secrets.DIGDIR_FDK_DEV_AUTODEPLOY }}
-      SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-
-  build-and-deploy-nginx:
-    needs: build-and-deploy-server
-    name: Deploy to nginx prod on merge to main branch
-    uses: Informasjonsforvaltning/workflows/.github/workflows/build-deploy-nox.yaml@main
-    with:
-      app_name: static-rdf-nginx
-      python_version: "3.12"
-      python_architecture: x64
-      environment: prod
-      cluster: digdir-fdk-prod
-      monorepo_app: True
-      nox_env: 1
-      nox_env_1_name: API_KEY
-      nox_cmd: "-s contract_tests"
-      dockerfile_context: ./nginx/
-      dockerfile: ./nginx/Dockerfile
-    secrets:
-      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      DIGDIR_FDK_AUTODEPLOY: ${{ secrets.DIGDIR_FDK_PROD_AUTODEPLOY }}
-      SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-      NOX_ENV_1_VALUE: ${{ secrets.TEST_API_KEY }}
-
-  deploy-nginx-to-demo:
-    needs: build-and-deploy-nginx
-    name: Deploy nginx to demo if prod-deploy is successful
-    uses: Informasjonsforvaltning/workflows/.github/workflows/deploy.yaml@main
-    with:
-      app_name: static-rdf-nginx
-      environment: demo
-      cluster: digdir-fdk-dev
-      monorepo_app: True
-    secrets:
-      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}   
       DIGDIR_FDK_AUTODEPLOY: ${{ secrets.DIGDIR_FDK_DEV_AUTODEPLOY }}
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/deploy-prod&demo.yaml
+++ b/.github/workflows/deploy-prod&demo.yaml
@@ -26,6 +26,7 @@ jobs:
     uses: Informasjonsforvaltning/workflows/.github/workflows/build-push.yaml@main
     with:
       app_name: static-rdf-nginx
+      monorepo_app: true
       environment: prod
       gh_environment: prod
       dockerfile: Dockerfile

--- a/.github/workflows/deploy-staging.yaml
+++ b/.github/workflows/deploy-staging.yaml
@@ -25,49 +25,44 @@ jobs:
       NOX_ENV_VALUE: ${{ secrets.TEST_API_KEY }}
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
-  build-and-deploy-server:
-    name: Build and deploy server to staging
+  build-server:
+    name: Build server image
     if: ${{ github.actor != 'dependabot[bot]' && github.event.pull_request.draft == false }}
-    uses: Informasjonsforvaltning/workflows/.github/workflows/build-deploy-nox.yaml@main
+    uses: Informasjonsforvaltning/workflows/.github/workflows/build-push.yaml@main
     with:
       app_name: static-rdf-server
-      python_version: "3.12"
-      python_architecture: x64
-      node_version: 22
       environment: staging
-      cluster: digdir-fdk-dev
-      nox_image: True
-      nox_env: 1
-      nox_env_1_name: API_KEY
-      run_safety: false
+      gh_environment: staging
     secrets:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      DIGDIR_FDK_AUTODEPLOY: ${{ secrets.DIGDIR_FDK_DEV_AUTODEPLOY }}
-      SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-      NOX_ENV_1_VALUE: ${{ secrets.TEST_API_KEY }}
 
-  build-and-deploy-nginx:
-    needs: build-and-deploy-server
-    name: Build and deploy nginx to staging
+  build-nginx:
+    name: Build nginx image
     if: ${{ github.actor != 'dependabot[bot]' && github.event.pull_request.draft == false }}
-    uses: Informasjonsforvaltning/workflows/.github/workflows/build-deploy-nox.yaml@main
+    uses: Informasjonsforvaltning/workflows/.github/workflows/build-push.yaml@main
     with:
       app_name: static-rdf-nginx
-      python_version: "3.12"
-      python_architecture: x64
       environment: staging
+      gh_environment: staging
+      dockerfile: Dockerfile
+      build_context: ./nginx/
+    secrets:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  deploy:
+    name: Deploy to staging environment
+    if: ${{ github.actor != 'dependabot[bot]' && github.event.pull_request.draft == false }}
+    needs: [build-server, build-nginx]
+    uses: Informasjonsforvaltning/workflows/.github/workflows/kustomize-deploy.yaml@main
+    with:
+      app_name: static-rdf-server
+      environment: staging
+      gh_environment: staging
       cluster: digdir-fdk-dev
-      monorepo_app: True
-      nox_env: 1
-      nox_env_1_name: API_KEY
-      nox_cmd: "-s contract_tests"
-      dockerfile_context: ./nginx/
-      dockerfile: ./nginx/Dockerfile
     secrets:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       DIGDIR_FDK_AUTODEPLOY: ${{ secrets.DIGDIR_FDK_DEV_AUTODEPLOY }}
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-      NOX_ENV_1_VALUE: ${{ secrets.TEST_API_KEY }}
 
   dependabot-build-server:
     name: Build server image on PR from dependabot
@@ -79,5 +74,5 @@ jobs:
     if: ${{ github.actor == 'dependabot[bot]' }}
     uses: Informasjonsforvaltning/workflows/.github/workflows/build.yaml@main
     with:
-      dockerfile: ./nginx/Dockerfile
-      dockerfile_context: ./nginx/
+      dockerfile: Dockerfile
+      build_context: ./nginx/

--- a/.github/workflows/deploy-staging.yaml
+++ b/.github/workflows/deploy-staging.yaml
@@ -42,6 +42,7 @@ jobs:
     uses: Informasjonsforvaltning/workflows/.github/workflows/build-push.yaml@main
     with:
       app_name: static-rdf-nginx
+      monorepo_app: true
       environment: staging
       gh_environment: staging
       dockerfile: Dockerfile

--- a/deploy/base/deployment-static-rdf.yaml
+++ b/deploy/base/deployment-static-rdf.yaml
@@ -1,0 +1,103 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: static-rdf
+  labels:
+    fdk.service: static-rdf
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      fdk.service: static-rdf
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        fdk.service: static-rdf
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: app
+                    operator: In
+                    values:
+                      - static-rdf
+      containers:
+        - name: static-rdf-server
+          image: static-rdf-server
+          imagePullPolicy: Always
+          env:
+            - name: API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: common
+                  key: STATIC_RDF_SERVER_API_KEY
+            - name: CORS_ORIGIN_PATTERNS
+              value: ""
+          ports:
+            - containerPort: 5000
+          resources:
+            requests:
+              memory: "200Mi"
+              cpu: "10m"
+            limits:
+              memory: "200Mi"
+          volumeMounts:
+            - mountPath: /srv/www/static-rdf-server
+              name: static-rdf-data
+          livenessProbe:
+            httpGet:
+              path: /ping
+              port: 5000
+            initialDelaySeconds: 60
+            periodSeconds: 90
+            successThreshold: 1
+            failureThreshold: 5
+          readinessProbe:
+            httpGet:
+              path: /ready
+              port: 5000
+            initialDelaySeconds: 120
+            periodSeconds: 90
+            successThreshold: 1
+            failureThreshold: 5
+        - name: static-rdf-nginx
+          image: static-rdf-nginx
+          imagePullPolicy: Always
+          ports:
+            - containerPort: 8080
+          resources:
+            requests:
+              memory: "100Mi"
+              cpu: "1m"
+            limits:
+              memory: "100Mi"
+          volumeMounts:
+            - mountPath: /srv/www/static-rdf-server
+              name: static-rdf-data
+              readOnly: true
+          livenessProbe:
+            httpGet:
+              path: /ping
+              port: 8080
+            initialDelaySeconds: 20
+            periodSeconds: 30
+            successThreshold: 1
+            failureThreshold: 5
+          readinessProbe:
+            httpGet:
+              path: /ready
+              port: 8080
+            initialDelaySeconds: 20
+            periodSeconds: 30
+            successThreshold: 1
+            failureThreshold: 5
+      volumes:
+        - name: static-rdf-data
+          persistentVolumeClaim:
+            claimName: static-rdf-server-claim0
+      restartPolicy: Always

--- a/deploy/base/kustomization.yaml
+++ b/deploy/base/kustomization.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - deployment-static-rdf.yaml
+  - service-static-rdf-server.yaml
+  - service-static-rdf-nginx.yaml
+images:
+  - name: static-rdf-server
+    newName: ghcr.io/informasjonsforvaltning/static-rdf-server
+    newTag: $(GIT_COMMIT_SHA)
+  - name: static-rdf-nginx
+    newName: ghcr.io/informasjonsforvaltning/static-rdf-nginx
+    newTag: $(GIT_COMMIT_SHA)

--- a/deploy/base/kustomization.yaml
+++ b/deploy/base/kustomization.yaml
@@ -10,5 +10,5 @@ images:
     newName: ghcr.io/informasjonsforvaltning/static-rdf-server
     newTag: $(GIT_COMMIT_SHA)
   - name: static-rdf-nginx
-    newName: ghcr.io/informasjonsforvaltning/static-rdf-nginx
+    newName: ghcr.io/informasjonsforvaltning/static-rdf-server/static-rdf-nginx
     newTag: $(GIT_COMMIT_SHA)

--- a/deploy/base/service-static-rdf-nginx.yaml
+++ b/deploy/base/service-static-rdf-nginx.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: static-rdf-nginx
+  labels:
+    fdk.service: static-rdf
+spec:
+  type: NodePort
+  ports:
+    - name: "8080"
+      port: 8080
+      targetPort: 8080
+  selector:
+    fdk.service: static-rdf

--- a/deploy/base/service-static-rdf-server.yaml
+++ b/deploy/base/service-static-rdf-server.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: static-rdf-server
+  labels:
+    fdk.service: static-rdf
+spec:
+  type: ClusterIP
+  ports:
+    - name: "5000"
+      port: 5000
+      targetPort: 5000
+  selector:
+    fdk.service: static-rdf

--- a/deploy/demo/kustomization.yaml
+++ b/deploy/demo/kustomization.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: demo
+resources:
+  - ../base
+  - storage.yaml
+patches:
+  - target:
+      kind: Deployment
+      name: static-rdf
+    patch: |
+      - op: replace
+        path: /spec/template/spec/containers/0/env/1/value
+        value: "https://demo.fellesdatakatalog.digdir.no,https://*.demo.fellesdatakatalog.digdir.no"

--- a/deploy/demo/storage.yaml
+++ b/deploy/demo/storage.yaml
@@ -1,0 +1,35 @@
+---
+kind: PersistentVolume
+apiVersion: v1
+metadata:
+  name: fdk-dev-demo-static-rdf-server
+spec:
+  storageClassName: ""
+  capacity:
+    storage: 9G
+  accessModes:
+    - ReadWriteOnce
+  nodeAffinity:
+    required:
+      nodeSelectorTerms:
+        - matchExpressions:
+            - key: topology.kubernetes.io/zone
+              operator: In
+              values:
+                - europe-north1-a
+  gcePersistentDisk:
+    pdName: fdk-dev-demo-static-rdf-server
+    fsType: ext4
+---
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: static-rdf-server-claim0
+spec:
+  storageClassName: ""
+  volumeName: fdk-dev-demo-static-rdf-server
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 9G

--- a/deploy/prod/kustomization.yaml
+++ b/deploy/prod/kustomization.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: prod
+resources:
+  - ../base
+  - storage.yaml
+patches:
+  - target:
+      kind: Deployment
+      name: static-rdf
+    patch: |
+      - op: replace
+        path: /spec/template/spec/containers/0/env/1/value
+        value: "https://fellesdatakatalog.digdir.no,https://*.fellesdatakatalog.digdir.no,https://data.norge.no,https://data.transportportal.no,https://transportportal.no"

--- a/deploy/prod/storage.yaml
+++ b/deploy/prod/storage.yaml
@@ -1,0 +1,35 @@
+---
+kind: PersistentVolume
+apiVersion: v1
+metadata:
+  name: fdk-prod-static-rdf-server
+spec:
+  storageClassName: ""
+  capacity:
+    storage: 9G
+  accessModes:
+    - ReadWriteOnce
+  nodeAffinity:
+    required:
+      nodeSelectorTerms:
+        - matchExpressions:
+            - key: topology.kubernetes.io/zone
+              operator: In
+              values:
+                - europe-north1-a
+  gcePersistentDisk:
+    pdName: fdk-prod-static-rdf-server
+    fsType: ext4
+---
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: static-rdf-server-claim0
+spec:
+  storageClassName: ""
+  volumeName: fdk-prod-static-rdf-server
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 9G

--- a/deploy/staging/kustomization.yaml
+++ b/deploy/staging/kustomization.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: staging
+resources:
+  - ../base
+  - storage.yaml
+patches:
+  - target:
+      kind: Deployment
+      name: static-rdf
+    patch: |
+      - op: replace
+        path: /spec/template/spec/containers/0/env/1/value
+        value: "https://staging.fellesdatakatalog.digdir.no,https://*.staging.fellesdatakatalog.digdir.no,http://localhost:*"

--- a/deploy/staging/storage.yaml
+++ b/deploy/staging/storage.yaml
@@ -1,0 +1,35 @@
+---
+kind: PersistentVolume
+apiVersion: v1
+metadata:
+  name: fdk-dev-staging-static-rdf-server
+spec:
+  storageClassName: ""
+  capacity:
+    storage: 9G
+  accessModes:
+    - ReadWriteOnce
+  nodeAffinity:
+    required:
+      nodeSelectorTerms:
+        - matchExpressions:
+            - key: topology.kubernetes.io/zone
+              operator: In
+              values:
+                - europe-north1-a
+  gcePersistentDisk:
+    pdName: fdk-dev-staging-static-rdf-server
+    fsType: ext4
+---
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: static-rdf-server-claim0
+spec:
+  storageClassName: ""
+  volumeName: fdk-dev-staging-static-rdf-server
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 9G


### PR DESCRIPTION
# Summary

- Combine static-rdf-server and static-rdf-nginx into a single pod (two
  containers) sharing the RWO persistent disk, fixing the recurring
  multi-attach deadlock where deployments hung in "waiting" on the disk
- Use `strategy: Recreate` so the old pod releases the disk before the
  new pod starts
- Add kustomize manifests under `deploy/` (base + staging/demo/prod)
- Migrate deploy workflows from `build-deploy-nox` to `build-push` +
  `kustomize-deploy`
- Align server probe timings with the current helm chart
- Mount the shared volume read-only in the nginx container (nginx only
  serves; only the server writes)

Note: one-time cutover per environment — delete the old `static-rdf-server`
and `static-rdf-nginx` **Deployments** so they release the RWO disk before
applying these manifests. The Services keep the same names, so `kubectl
apply` updates them in place — no Service deletion needed.

- Publish the nginx image to its monorepo path by setting `monorepo_app: true` on the `build-nginx` jobs (the central `build-push.yaml` only honours `app_name` when this is set; without it nginx was being pushed over the server image and never produced its own). The kustomization now references `ghcr.io/informasjonsforvaltning/static-rdf-server/static-rdf-nginx`, the existing public package, fixing the 403/ImagePullBackOff on nginx.

